### PR TITLE
remove bottle :unneeded (deprecated)

### DIFF
--- a/Formula/meroxa.rb
+++ b/Formula/meroxa.rb
@@ -7,7 +7,6 @@ class Meroxa < Formula
   homepage "https://meroxa.io"
   version "1.4.0"
   license "Apache 2.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
`bottle :unneeded` has been deprecated and should be removed.

Currently calling `brew update` with the Meroxa CLI outputs the following warning:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the meroxa/taps tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/meroxa/homebrew-taps/Formula/meroxa.rb:10
```